### PR TITLE
fix: grumbler scripts 8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 /* @flow */
 
 module.exports = {
-  extends: require.resolve("@krakenjs/grumbler-scripts/config/.eslintrc-node"),
+  extends: "@krakenjs/eslint-config-grumbler/eslintrc-node",
 };

--- a/.flowconfig
+++ b/.flowconfig
@@ -9,7 +9,6 @@
 [include]
 [libs]
 flow-typed
-node_modules/grumbler-scripts/declarations.js
 [options]
 module.name_mapper='^src\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
 experimental.const_params=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 registry=https://registry.npmjs.org/
-save=false
 package-lock=false

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@krakenjs/babel-config-grumbler/babel-node"
+  "extends": "@krakenjs/babel-config-grumbler/babelrc-node"
 }

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@krakenjs/grumbler-scripts/config/.babelrc-node"
+  "extends": "@krakenjs/babel-config-grumbler/babel-node"
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
-    "@krakenjs/grumbler-scripts": "^8.0.3",
+    "@krakenjs/grumbler-scripts": "^8.0.4",
     "babel-core": "^7.0.0-bridge.0",
     "flow-bin": "0.85.0",
     "husky": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
     "@commitlint/config-conventional": "^16.2.1",
-    "@krakenjs/grumbler-scripts": "^7.0.0",
+    "@krakenjs/grumbler-scripts": "^8.0.3",
     "babel-core": "^7.0.0-bridge.0",
     "flow-bin": "0.85.0",
     "husky": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "flow-bin": "0.85.0",
     "flow-typed": "^3.8.0",
     "husky": "^7.0.4",
+    "jest": "^29.3.1",
     "lint-staged": "^12.4.0",
     "prettier": "^2.6.2",
     "standard-version": "^9.3.2"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@krakenjs/grumbler-scripts": "^8.0.4",
     "babel-core": "^7.0.0-bridge.0",
     "flow-bin": "0.85.0",
+    "flow-typed": "^3.8.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.4.0",
     "prettier": "^2.6.2",


### PR DESCRIPTION
[DTPPSDK-947](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-947)

* Migrated to grumbler scripts v8.
* Added `flow-typed` and `jest` as dev dependencies